### PR TITLE
Expose `dump_terms` from top level

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -5,7 +5,7 @@ import logging
 from .api import get_grounder, get_models, get_names, ground, make_grounder, annotate
 from .grounder import Grounder, ScoredMatch
 from .pandas_utils import ground_df, ground_df_map
-from .term import Term
+from .term import Term, dump_terms
 
 __all__ = [
     'ground',
@@ -14,6 +14,7 @@ __all__ = [
     'get_names',
     'get_grounder',
     'make_grounder',
+    "dump_terms",
     # Classes
     'Term',
     'Grounder',


### PR DESCRIPTION
This quality of life improvement reduces the need to remember that the `dump_terms` function is in the `gilda.term` submodule, and can now be imported like:

```python
from gilda import dump_terms
```

This has the side benefit of being able to reduce the number of lines of imports in many files, too.