### PR TITLE
Improve safety of NER build

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -111,7 +111,11 @@ class Grounder(object):
     def _build_prefix_index(self):
         prefix_index = defaultdict(set)
         for norm_term in self.entries:
+            if not norm_term:
+                continue
             parts = norm_term.split()
+            if not parts:
+                continue
             prefix_index[parts[0]].add(len(parts))
         self.prefix_index = dict(prefix_index)
 

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -52,6 +52,8 @@ class Term(object):
                  organism=None, source_db=None, source_id=None):
         if not text:
             raise ValueError('Text for Term cannot be empty')
+        if not norm_text.strip():
+            raise ValueError('Normalized text for Term cannot be empty')
         self.norm_text = norm_text
         self.text = text
         self.db = db


### PR DESCRIPTION
This PR updates the NER index build to skip entries whose norm terms are none or contain an empty string. This shouldn't happen in practice, but depending on the pipeline used to construct terms, this might happen. A few alternatives to consider:

1. Have the Term class raise errors when None is given for norm_text
2. Raise an error in the NER index build