### PR TITLE
Update terms with latest resources

### DIFF
--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -47,7 +47,8 @@ correct_assertions = {'Stat': {'FPLX': 'STAT'},
                       'GR': {'HGNC': '7978'},
                       'integrin alpha': {'FPLX': 'ITGA'},
                       'DC': {'MESH': 'D003713'},
-                      'BMD': {'MESH': 'D015519'}}
+                      'BMD': {'MESH': 'D015519'},
+                      'angina': {'EFO': '0003913'}}
 
 
 incorrect_assertions = {'IGF': {'HGNC': '5464'},

--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 import logging
 

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -335,12 +335,24 @@ def generate_uniprot_terms(download=False, organisms=None):
     if not organisms:
         organisms = popular_organisms
     path = os.path.join(resource_dir, 'up_synonyms.tsv')
-    org_filter_str = ' OR '.join(organisms)
     if not os.path.exists(path) or download:
-        url = (f'https://legacy.uniprot.org/uniprot/?format=tab&columns=id,'
-               f'genes(PREFERRED),genes(ALTERNATIVE),protein%20names,organism-id&sort=score&'
-               f'query=reviewed:yes&fil=organism:{org_filter_str}')
+        columns = [
+            'accession',        # id
+            'gene_primary',     # genes(PREFERRED)
+            #'gene_names',       # genes(PREFERRED)
+            'gene_synonym',      # genes(ALTERNATIVE)'
+            'protein_name',     # protein names
+            'organism_id',       # organism-id
+        ]
+        org_filter_str = '+OR+'.join(f'(taxonomy_id:{org})' for org in organisms)
+        query = f'reviewed:true+AND+({org_filter_str})'
+        url = (f'https://rest.uniprot.org/uniprotkb/stream?'
+               f'format=tsv&'
+               f'query={query}&'
+               f'compressed=false&'
+               f'fields={",".join(columns)}')
         logger.info('Downloading UniProt resource file')
+        print(url)
         res = requests.get(url)
         with open(path, 'w') as fh:
             fh.write(res.text)
@@ -355,7 +367,7 @@ def generate_uniprot_terms(download=False, organisms=None):
 def get_terms_from_uniprot_row(row):
     terms = []
     up_id = row['Entry']
-    organism = row['Organism ID']
+    organism = row['Organism (ID)']
 
     # As of 3/2/2022 there is an error in UniProt data that we need to manually
     # patch here
@@ -371,8 +383,8 @@ def get_terms_from_uniprot_row(row):
     # P34539»·; »·; »·
     # where there are two genes but neither of them have names or
     # synonyms listed.
-    primary_gene_names = row['Gene names  (primary )'].split('; ')
-    gene_synonyms = row['Gene names  (synonym )'].split('; ')
+    primary_gene_names = row['Gene Names (primary)'].split('; ')
+    gene_synonyms = row['Gene Names (synonym)'].split('; ')
 
     multi_gene = len(primary_gene_names) > 1
 

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -336,13 +336,13 @@ def generate_uniprot_terms(download=False, organisms=None):
         organisms = popular_organisms
     path = os.path.join(resource_dir, 'up_synonyms.tsv')
     if not os.path.exists(path) or download:
+        # Columns according to the new API, comments for old API
         columns = [
-            'accession',        # id
-            'gene_primary',     # genes(PREFERRED)
-            #'gene_names',       # genes(PREFERRED)
-            'gene_synonym',      # genes(ALTERNATIVE)'
-            'protein_name',     # protein names
-            'organism_id',       # organism-id
+            'accession',     # id
+            'gene_primary',  # genes(PREFERRED)
+            'gene_synonym',  # genes(ALTERNATIVE)'
+            'protein_name',  # protein names
+            'organism_id',   # organism-id
         ]
         org_filter_str = '+OR+'.join(f'(taxonomy_id:{org})' for org in organisms)
         query = f'reviewed:true+AND+({org_filter_str})'
@@ -352,7 +352,6 @@ def generate_uniprot_terms(download=False, organisms=None):
                f'compressed=false&'
                f'fields={",".join(columns)}')
         logger.info('Downloading UniProt resource file')
-        print(url)
         res = requests.get(url)
         with open(path, 'w') as fh:
             fh.write(res.text)


### PR DESCRIPTION
This PR updates the default Gilda terms file with the latest version of resources such as UniProt, HGNC, MeSH, GO, etc. The FamPlex benchmark got better due to the recognition of a new EFO term, and the BioID evaluation also generally got better. There are a couple of regressions that I tracked down: nuclear chromatin and cytoplasmic chromatin are curated in the benchmark to obsolete GO terms which were replaced by a term (https://amigo.geneontology.org/amigo/term/GO:0000785) for which these are narrow synonyms and therefore there is no longer a correct GO term to ground these to.