### PR TITLE
Make instantiation of Grounder more flexible

### DIFF
--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -1,5 +1,6 @@
 from gilda.term import Term
 from gilda.grounder import Grounder, filter_for_organism
+import pytest
 from . import appreq
 
 
@@ -256,3 +257,42 @@ def test_sqlite():
 def test_strip_whitespace():
     matches = gr.ground(' inflammatory response ')
     assert matches
+
+
+def test_instantiate():
+    """Test instantiating the grounder with different data structures."""
+    term = Term(
+        "mitochondria",
+        "Mitochondria",
+        "GO",
+        "GO:0005739",
+        "mitochondrion",
+        "synonym",
+        "mesh",
+        None,
+        "MESH",
+        "D008928",
+    )
+
+    # test instantiating with list
+    gr = Grounder([term])
+    assert len(gr.ground("mitochondria")) == 1
+
+    # test instantiating with set
+    gr = Grounder({term})
+    assert len(gr.ground("mitochondria")) == 1
+
+    # test instantiating with tuple
+    gr = Grounder((term,))
+    assert len(gr.ground("mitochondria")) == 1
+
+    # test instantiating with iterable
+    gr = Grounder(iter([term]))
+    assert len(gr.ground("mitochondria")) == 1
+
+    # test instantiating with dict
+    gr = Grounder({term.norm_text: [term]})
+    assert len(gr.ground("mitochondria")) == 1
+
+    with pytest.raises(TypeError):
+        Grounder(5)


### PR DESCRIPTION
This PR adds the ability to add any kind of iterable as the argument to `gilda.Grounder` instead of limiting to just lists. This is useful since there are several functions in various places that generate iterables of Gilda Term objects that would be convenient to directly stick in a `Grounder` without having to cast to a list. This PR also adds some tests to check all of the various ways a Grounder can be instantiated