### PR TITLE
Add default grounding resources to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ needed. These resources include:
 - [CHeBI](https://bioregistry.io/chebi) (small molecules, metabolites, etc.)
 - [GO](https://bioregistry.io/go) (biological processes, molecular functions, complexes)
 - [DOID](https://bioregistry.io/doid) (diseases)
-- [EFO](https://bioregistry.io/efo) (experimental factors)
+- [EFO](https://bioregistry.io/efo) (experimental factors: cell lines, cell types, anatomical entities, etc.)
 - [HP](https://bioregistry.io/hp) (human phenotypes)
-- [MeSH](https://bioregistry.io/mesh) (general)
+- [MeSH](https://bioregistry.io/mesh) (general: diseases, proteins, small molecules, cell types, etc.)
 - [Adeft](https://github.com/gyorilab/adeft) (misc. terms corresponding to ambiguous acronyms)
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ run the container based on the `docker-compose.yml` configuration:
 $ docker-compose up
 ```
 
+## Default grounding resources
+
+Gilda is customizable with terms coming from different vocabularies. However,
+Gilda comes with a default set of resources from which terms are collected
+(almost 2 million entries as of v1.1.0), without any additional configuration
+needed. These resources include:
+- [HGNC](https://bioregistry.io/hgnc) (human genes)
+- [UniProt](https://bioregistry.io/uniprot) (human and model organism proteins)
+- [FamPlex](https://bioregistry.io/famplex) (human protein families and complexes)
+- [CHeBI](https://bioregistry.io/chebi) (small molecules, metabolites, etc.)
+- [GO](https://bioregistry.io/go) (biological processes, molecular functions, complexes)
+- [DOID](https://bioregistry.io/doid) (diseases)
+- [EFO](https://bioregistry.io/efo) (experimental factors)
+- [HP](https://bioregistry.io/hp) (human phenotypes)
+- [MeSH](https://bioregistry.io/mesh) (general)
+- [Adeft](https://github.com/gyorilab/adeft) (misc. terms corresponding to ambiguous acronyms)
+
 ## Citation
 
 ```bibtex


### PR DESCRIPTION
This PR provides a list and brief description of the built-in default grounding resources in Gilda.

Fixes #134 

