### PR TITLE
Allow for 'classic' gunicorn running

### DIFF
--- a/gilda/app/__init__.py
+++ b/gilda/app/__init__.py
@@ -2,12 +2,19 @@ import argparse
 from .app import get_app
 
 
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         description='Run the grounding app.')
     parser.add_argument('--host', default='0.0.0.0')
     parser.add_argument('--port', default=8001, type=int)
     parser.add_argument('--terms')
     args = parser.parse_args()
-    app = get_app(terms=args.terms)
-    app.run(host=args.host, port=args.port, threaded=False)
+    return args
+
+
+if __name__ == '__main__':
+    _args = parse_args()
+    app = get_app(_args.terms)
+    app.run(_args.host, _args.port, threaded=False)
+else:
+    gunicorn_app = get_app()

--- a/gilda/app/__init__.py
+++ b/gilda/app/__init__.py
@@ -1,3 +1,13 @@
+"""
+Run the grounding app.
+
+Run as module:
+    `python -m gilda.app --host <host> --port <port> --terms <terms>`
+
+Run with gunicorn:
+    `gunicorn -w <worker count> -b <host>:<port> -t <timeout> gilda.app:gunicorn_app`
+"""
+
 import argparse
 from .app import get_app
 

--- a/gilda/app/__init__.py
+++ b/gilda/app/__init__.py
@@ -5,32 +5,15 @@ Run as module:
     `python -m gilda.app --host <host> --port <port> --terms <terms>`
 
 Run with gunicorn:
-    `gunicorn -w <worker count> -b <host>:<port> -t <timeout> gilda.app:gunicorn_app`
+    `gunicorn -w <worker count> -b <host>:<port> -t <timeout> gilda.app:gilda_app`
 
-For this use case, set the `GILDA_TERMS` environment variable to the path to the
-terms file.
+In case a non-standard set of terms is to be used, set the `GILDA_TERMS`
+environment variable to the path to the terms file.
 """
 
-import argparse
+import os
 from .app import get_app
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description='Run the grounding app.')
-    parser.add_argument('--host', default='0.0.0.0')
-    parser.add_argument('--port', default=8001, type=int)
-    parser.add_argument('--terms')
-    args = parser.parse_args()
-    return args
-
-
-if __name__ == '__main__':
-    _args = parse_args()
-    app = get_app(_args.terms)
-    app.run(_args.host, _args.port, threaded=False)
-else:
-    # Assume the terms file is set in the environment
-    import os
-    terms = os.environ.get('GILDA_TERMS')
-    gunicorn_app = get_app(terms=terms)
+terms = os.environ.get('GILDA_TERMS')
+gilda_app = get_app(terms=terms)

--- a/gilda/app/__init__.py
+++ b/gilda/app/__init__.py
@@ -6,6 +6,9 @@ Run as module:
 
 Run with gunicorn:
     `gunicorn -w <worker count> -b <host>:<port> -t <timeout> gilda.app:gunicorn_app`
+
+For this use case, set the `GILDA_TERMS` environment variable to the path to the
+terms file.
 """
 
 import argparse
@@ -27,4 +30,7 @@ if __name__ == '__main__':
     app = get_app(_args.terms)
     app.run(_args.host, _args.port, threaded=False)
 else:
-    gunicorn_app = get_app()
+    # Assume the terms file is set in the environment
+    import os
+    terms = os.environ.get('GILDA_TERMS')
+    gunicorn_app = get_app(terms=terms)

--- a/gilda/app/__main__.py
+++ b/gilda/app/__main__.py
@@ -1,5 +1,8 @@
-from . import main
+from .app import get_app
+from . import parse_args
 
 
 if __name__ == '__main__':
-    main()
+    args = parse_args()
+    app = get_app(args.terms)
+    app.run(args.host, args.port, threaded=False)

--- a/gilda/app/__main__.py
+++ b/gilda/app/__main__.py
@@ -1,3 +1,9 @@
+"""
+Runs the Gilda grounding app as a module. Usage:
+
+    `python -m gilda.app --host <host> --port <port> --terms <terms>`
+"""
+
 from .app import get_app
 from . import parse_args
 

--- a/gilda/app/__main__.py
+++ b/gilda/app/__main__.py
@@ -4,8 +4,18 @@ Runs the Gilda grounding app as a module. Usage:
     `python -m gilda.app --host <host> --port <port> --terms <terms>`
 """
 
+import argparse
 from .app import get_app
-from . import parse_args
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Run the grounding app.')
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', default=8001, type=int)
+    parser.add_argument('--terms')
+    args = parser.parse_args()
+    return args
 
 
 if __name__ == '__main__':

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -298,10 +298,3 @@ def _mount_home_redirect(app):
     def home_redirect():
         """Redirect the home url to the API documentation."""
         return redirect("/apidocs")
-
-
-if __name__ == '__main__':
-    app = get_app()
-    app.run()
-else:
-    gunicorn_app = get_app()

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -298,3 +298,10 @@ def _mount_home_redirect(app):
     def home_redirect():
         """Redirect the home url to the API documentation."""
         return redirect("/apidocs")
+
+
+if __name__ == '__main__':
+    app = get_app()
+    app.run()
+else:
+    gunicorn_app = get_app()

--- a/gilda/app/templates/base.html
+++ b/gilda/app/templates/base.html
@@ -38,8 +38,8 @@
           Gilda is developed by the <a href="https://gyorilab.github.io"
           target="_blank">Gyori Lab for Computational Biomedicine</a>
           at <a href="https://www.northeastern.edu" target="_blank">Northeastern University</a>.
-          Its development was funded by DARPA grants W911NF-15-1-0544 and
-          W911NF-20-1-0255.
+          Its development is funded by DARPA grants W911NF-15-1-0544,
+          W911NF-20-1-0255, and HR00112220036.
           Point of contact: <a href="mailto:b.gyori@northeastern.edu">Benjamin M. Gyori</a>.
       </p>
     </div>


### PR DESCRIPTION
This PR adds code that allows the gilda app to be run with gunicorn.

To run with gunicorn:
```bash
gunicorn -w 2 -b :8000 -t 600 gilda.app:gunicorn_app
```

To run as module:
```bash
python -m gilda.app --port 8000 --host 127.0.0.5
```