### PR TITLE
Implement context text for annotation and fix capitalization

### DIFF
--- a/gilda/api.py
+++ b/gilda/api.py
@@ -113,6 +113,7 @@ def annotate(
     organisms=None,
     namespaces=None,
     return_first: bool = True,
+    context_text: str = None,
 ):
     """Annotate a given text with Gilda (i.e., do named entity recognition).
 
@@ -131,8 +132,11 @@ def annotate(
     namespaces : list[str], optional
         A list of namespaces to pass to the grounder to restrict the matches
         to. By default, no restriction is applied.
-    return_first:
+    return_first :
         If true, only returns the first result. Otherwise, returns all results.
+    context_text :
+        A longer span of text that serves as additional context for the text
+        being annotated for disambiguation purposes.
 
     Returns
     -------
@@ -150,6 +154,7 @@ def annotate(
         organisms=organisms,
         namespaces=namespaces,
         return_first=return_first,
+        context_text=context_text,
     )
 
 

--- a/gilda/ner.py
+++ b/gilda/ner.py
@@ -70,6 +70,7 @@ def annotate(
     organisms=None,
     namespaces=None,
     return_first: bool = True,
+    context_text: str = None,
 ) -> List[Annotation]:
     """Annotate a given text with Gilda.
 
@@ -90,8 +91,11 @@ def annotate(
     namespaces : list[str], optional
         A list of namespaces to pass to the grounder to restrict the matches
         to. By default, no restriction is applied.
-    return_first:
+    return_first :
         If true, only returns the first result. Otherwise, returns all results.
+    context_text :
+        A longer span of text that serves as additional context for the text
+        being annotated for disambiguation purposes.
 
     Returns
     -------
@@ -131,9 +135,9 @@ def annotate(
 
             # Find the largest matching span
             for span in sorted(applicable_spans, reverse=True):
-                txt_span = ' '.join(words[idx:idx+span])
+                txt_span = ' '.join(raw_words[idx:idx+span])
                 matches = grounder.ground(
-                    txt_span, context=text,
+                    txt_span, context=text if context_text is None else context_text,
                     organisms=organisms, namespaces=namespaces,
                 )
                 if matches:

--- a/gilda/tests/test_ner.py
+++ b/gilda/tests/test_ner.py
@@ -75,3 +75,20 @@ def test_get_all():
     assert "hgnc:3467" in curies  # ESR1
     assert "fplx:ESR" in curies
     assert "GO:0005783" in curies  # endoplasmic reticulum
+
+
+def test_context_test():
+    text = "This is about ER."
+    context_text = "Estrogen receptor (ER) is a protein family."
+    results = gilda.annotate(text, context_text=context_text)
+    assert len(results) == 1
+    assert results[0][1].term.get_curie() == "fplx:ESR"
+    assert results[0][0] == "ER"
+    assert results[0][2:4] == (14, 16)
+
+    context_text = "Calcium is released from the ER."
+    results = gilda.annotate(text, context_text=context_text)
+    assert len(results) == 1
+    assert results[0][1].term.get_curie() == "GO:0005783"
+    assert results[0][0] == "ER"
+    assert results[0][2:4] == (14, 16)


### PR DESCRIPTION
This PR implements the ability to add longer context text for NER annotations for disambiguation purposes. It also fixes an issue where a normalized rather than a raw entity text was used for grounding within the annotation function.