### PR TITLE
Make annotation return a list of Annotation object with a list of ScoredMatches

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -2,8 +2,9 @@ __version__ = '1.2.1'
 
 import logging
 
-from .api import get_grounder, get_models, get_names, ground, make_grounder, annotate
-from .grounder import Grounder, ScoredMatch
+from .api import get_grounder, get_models, get_names, ground, make_grounder, \
+    annotate
+from .grounder import Grounder, ScoredMatch, Annotation
 from .pandas_utils import ground_df, ground_df_map
 from .term import Term, dump_terms
 
@@ -19,6 +20,7 @@ __all__ = [
     'Term',
     'Grounder',
     'ScoredMatch',
+    'Annotation',
     # Meta
     '__version__',
     # Pandas utilities

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -112,7 +112,6 @@ def annotate(
     sent_split_fun=None,
     organisms=None,
     namespaces=None,
-    return_first: bool = True,
     context_text: str = None,
 ):
     """Annotate a given text with Gilda (i.e., do named entity recognition).
@@ -132,18 +131,16 @@ def annotate(
     namespaces : list[str], optional
         A list of namespaces to pass to the grounder to restrict the matches
         to. By default, no restriction is applied.
-    return_first :
-        If true, only returns the first result. Otherwise, returns all results.
     context_text :
         A longer span of text that serves as additional context for the text
         being annotated for disambiguation purposes.
 
     Returns
     -------
-    list[tuple[str, ScoredMatch, int, int]]
-        A list of tuples of start and end character offsets of the text
-        corresponding to the entity, the entity text, and the ScoredMatch
-        object corresponding to the entity.
+    list[tuple[str, list[ScoredMatch], int, int]]
+        A list of matches where each match is a tuple consisting of
+        the matches text span, the list of ScoredMatches, and the
+        start and end character offsets of the text span.
     """
     from .ner import annotate as _annotate
 
@@ -153,7 +150,6 @@ def annotate(
         sent_split_fun=sent_split_fun,
         organisms=organisms,
         namespaces=namespaces,
-        return_first=return_first,
         context_text=context_text,
     )
 

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -9,7 +9,7 @@ __all__ = [
 
 from typing import List, Mapping, Union, Optional
 
-from gilda.grounder import Grounder
+from gilda.grounder import Grounder, Annotation
 from gilda.term import Term
 
 
@@ -113,7 +113,7 @@ def annotate(
     organisms=None,
     namespaces=None,
     context_text: str = None,
-):
+) -> List[Annotation]:
     """Annotate a given text with Gilda (i.e., do named entity recognition).
 
     Parameters
@@ -137,14 +137,15 @@ def annotate(
 
     Returns
     -------
-    list[tuple[str, list[ScoredMatch], int, int]]
-        A list of matches where each match is a tuple consisting of
-        the matches text span, the list of ScoredMatches, and the
-        start and end character offsets of the text span.
+    list[Annotation]
+        A list of matches where each match is an Annotation object
+        which contains as attributes the text span that was matches,
+        the list of ScoredMatches, and the start and end character offsets of
+        the text span.
     """
-    from .ner import annotate as _annotate
+    import gilda.ner
 
-    return _annotate(
+    return gilda.ner.annotate(
         text,
         grounder=grounder,
         sent_split_fun=sent_split_fun,

--- a/gilda/app/templates/ner_matches.html
+++ b/gilda/app/templates/ner_matches.html
@@ -18,17 +18,20 @@
             <thead>
             <tr>
                 <th>Span</th>
+                <th>Text</th>
                 <th>Grounding</th>
-                <th>Name</th>
+                <th>Standard name</th>
                 <th>Score</th>
-                <th>Additional Groundings</th>
+                <th>Additional groundings</th>
             </tr>
             </thead>
             <tbody>
-            {% for text, matches, start, end in annotations %}
+            {% for annotation in annotations %}
                 <tr>
-                    {% set match_curie = matches[0].term.get_curie() %}
-                    <td>{{start}}-{{end}}</td>
+                    {% set match = annotation['matches'][0] %}
+                    {% set match_curie = match.term.get_curie() %}
+                    <td>{{ annotation['start'] }}-{{ annotation['end'] }}</td>
+                    <td>{{ annotation['text'] }}</td>
                     <td>
                         <a class="label label-primary" href="{{ match['url'] }}">
                             {{ match_curie }}

--- a/gilda/app/templates/ner_matches.html
+++ b/gilda/app/templates/ner_matches.html
@@ -25,9 +25,9 @@
             </tr>
             </thead>
             <tbody>
-            {% for text, match, start, end in annotations %}
+            {% for text, matches, start, end in annotations %}
                 <tr>
-                    {% set match_curie = match.term.get_curie() %}
+                    {% set match_curie = matches[0].term.get_curie() %}
                     <td>{{start}}-{{end}}</td>
                     <td>
                         <a class="label label-primary" href="{{ match['url'] }}">

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -26,6 +26,7 @@ __all__ = [
     "Grounder",
     "GrounderInput",
     "ScoredMatch",
+    "Annotation",
     "load_terms_file",
     "load_entries_from_terms_file",
     "filter_for_organism",
@@ -650,6 +651,37 @@ class ScoredMatch(object):
             get_identifiers_curie(db, db_id): get_identifiers_url(db, db_id)
             for db, db_id in self.get_groundings()
         }
+
+
+class Annotation:
+    """A class representing a named entity annotation in a given text.
+
+    Attributes
+    ----------
+    text : str
+        The text span that was annotated.
+    matches : list[ScoredMatch]
+        The list of scored matches for the text span.
+    start : int
+        The start character offset of the text span.
+    end : int
+        The end character offset of the text span.
+    """
+    def __init__(self, text: str, matches: List[ScoredMatch], start: int,
+                 end: int):
+        self.text = text
+        self.matches = matches
+        self.start = start
+        self.end = end
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return (f"Annotation({self.text}, {self.matches}, {self.start}, "
+                f"{self.end})")
+
+
 
 
 def load_entries_from_terms_file(terms_file: Union[str, Path]) -> Iterator[Term]:

--- a/gilda/ner.py
+++ b/gilda/ner.py
@@ -50,44 +50,17 @@ from typing import List
 from nltk.corpus import stopwords
 from nltk.tokenize import sent_tokenize
 
-from gilda import ScoredMatch, get_grounder
+from gilda import get_grounder
+from gilda.grounder import Annotation
 from gilda.process import normalize
 
 __all__ = [
     "annotate",
     "get_brat",
-    "Annotation",
     "stop_words"
 ]
 
 stop_words = set(stopwords.words('english'))
-
-
-class Annotation:
-    """A class to represent an annotation.
-
-    Attributes
-    ----------
-    text : str
-        The text span that was annotated.
-    matches : list[ScoredMatch]
-        The list of scored matches for the text span.
-    start : int
-        The start character offset of the text span.
-    end : int
-        The end character offset of the text span.
-    """
-    def __init__(self, text: str, matches: List[ScoredMatch], start: int, end: int):
-        self.text = text
-        self.matches = matches
-        self.start = start
-        self.end = end
-
-    def __repr__(self):
-        return str(self)
-
-    def __str__(self):
-        return f"Annotation({self.text}, {self.matches}, {self.start}, {self.end})"
 
 
 def annotate(

--- a/gilda/tests/test_ner.py
+++ b/gilda/tests/test_ner.py
@@ -28,14 +28,14 @@ def test_annotate():
     assert annotations[6][2:4] == (56, 63)  # protein
 
     # Check that the curies are correct
-    assert isinstance(annotations[0][1], gilda.ScoredMatch)
-    assert annotations[0][1].term.get_curie() == "CHEBI:36080"
-    assert annotations[1][1].term.get_curie() == "hgnc:1097"
-    assert annotations[2][1].term.get_curie() == "mesh:D010770"
-    assert annotations[3][1].term.get_curie() == "hgnc:1097"
-    assert annotations[4][1].term.get_curie() == "mesh:D005796"
-    assert annotations[5][1].term.get_curie() == "hgnc:1097"
-    assert annotations[6][1].term.get_curie() == "CHEBI:36080"
+    assert isinstance(annotations[0][1][0], gilda.ScoredMatch)
+    assert annotations[0][1][0].term.get_curie() == "CHEBI:36080"
+    assert annotations[1][1][0].term.get_curie() == "hgnc:1097"
+    assert annotations[2][1][0].term.get_curie() == "mesh:D010770"
+    assert annotations[3][1][0].term.get_curie() == "hgnc:1097"
+    assert annotations[4][1][0].term.get_curie() == "mesh:D005796"
+    assert annotations[5][1][0].term.get_curie() == "hgnc:1097"
+    assert annotations[6][1][0].term.get_curie() == "CHEBI:36080"
 
 
 def test_get_brat():
@@ -66,12 +66,12 @@ def test_get_brat():
 
 def test_get_all():
     full_text = "This is about ER."
-    results = gilda.annotate(full_text, return_first=False)
-    assert len(results) > 1
-    curies = {
-        scored_match.term.get_curie()
-        for _, scored_match, _, _ in results
-    }
+    results = gilda.annotate(full_text)
+    assert len(results) == 1
+    curies = set()
+    for _, scored_matches, _, _ in results:
+        for scored_match in scored_matches:
+            curies.add(scored_match.term.get_curie())
     assert "hgnc:3467" in curies  # ESR1
     assert "fplx:ESR" in curies
     assert "GO:0005783" in curies  # endoplasmic reticulum
@@ -82,13 +82,13 @@ def test_context_test():
     context_text = "Estrogen receptor (ER) is a protein family."
     results = gilda.annotate(text, context_text=context_text)
     assert len(results) == 1
-    assert results[0][1].term.get_curie() == "fplx:ESR"
+    assert results[0][1][0].term.get_curie() == "fplx:ESR"
     assert results[0][0] == "ER"
     assert results[0][2:4] == (14, 16)
 
     context_text = "Calcium is released from the ER."
     results = gilda.annotate(text, context_text=context_text)
     assert len(results) == 1
-    assert results[0][1].term.get_curie() == "GO:0005783"
+    assert results[0][1][0].term.get_curie() == "GO:0005783"
     assert results[0][0] == "ER"
     assert results[0][2:4] == (14, 16)


### PR DESCRIPTION
This PR changes the result of `annotate` such that a list of Annotation objects are returned each of which carries all ScoredMatches for the given span. Previously a tuple was returned with the second element either being only the top match, or multiple annotations were returned for the same text span in a flattened list.