### PR TITLE
Fix corner case with trailing space in synonym

### DIFF
--- a/gilda/scorer.py
+++ b/gilda/scorer.py
@@ -126,12 +126,14 @@ def generate_match(query, ref, beginning_of_sentence=False):
     # with a single ASCII space, and all kinds of dashes with a single
     # ASCII dash.
     query = replace_dashes(replace_whitespace(query))
-    ref = replace_dashes(replace_whitespace(ref))
+    # Corner case: some synonyms may have a trailing space which we can
+    # safely remove to avoid issues in the comparison
+    ref = replace_whitespace(ref).rstrip(' ')
+    ref = replace_dashes(ref)
 
     # If we have an exact match at this point then we can return immediately
     if not beginning_of_sentence and query == ref:
         return Match(query, ref, exact=True)
-
     query_suffix = query
     ref_suffix = ref
     query_pieces = ['']

--- a/gilda/tests/test_ner.py
+++ b/gilda/tests/test_ner.py
@@ -102,3 +102,10 @@ def test_punctuation_outside_entities():
     assert len(res) == 3
 
     assert [ann.text for ann in res] == ['EGF', 'EGFR', 'receptor']
+
+
+def test_synonym_corner_case():
+    # Context: EFO contains the synonyms "transthyretin " with a trailing
+    # space, this triggers an indexing error corner case when followed by -
+    res = gilda.annotate('transthyretin -')
+    assert res


### PR DESCRIPTION
This PR fixes a very rare corner case which stems from unexpected trailing spaces in synonyms in external sources when the same word is followed by a dash in the input text.