### PR TITLE
Fix curie presenation and linkout

### DIFF
--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -100,8 +100,8 @@ scored_match_model = api.model(
     "ScoredMatch",
     {'term': fields.Nested(term_model, description='The term that was matched'),
      'url': fields.String(
-         description='Identifiers.org URL for the matched term.',
-         example='https://identifiers.org/hgnc:3236'
+         description='bioregistry.io URL for the matched term.',
+         example='https://bioregistry.io/hgnc:3236'
      ),
      'score': fields.Float(
          description='The score assigned to the matched term.',

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -15,7 +15,7 @@ from urllib.request import urlretrieve
 from adeft.disambiguate import load_disambiguator
 from adeft.modeling.classify import load_model_info
 from adeft import available_shortforms as available_adeft_models
-from .term import Term, get_identifiers_curie, get_identifiers_url
+from .term import Term, get_curie, get_url
 from .process import normalize, replace_dashes, replace_greek_uni, \
     replace_greek_latin, replace_greek_spelled_out, depluralize, \
     replace_roman_arabic
@@ -578,7 +578,7 @@ class ScoredMatch(object):
     def __init__(self, term: Term, score, match: Match, disambiguation=None,
                  subsumed_terms=None):
         self.term = term
-        self.url = term.get_idenfiers_url()
+        self.url = term.get_url()
         self.score = score
         self.match = match
         self.disambiguation = disambiguation
@@ -648,7 +648,7 @@ class ScoredMatch(object):
     def get_grounding_dict(self) -> Mapping[str, str]:
         """Get the groundings as CURIEs and URLs."""
         return {
-            get_identifiers_curie(db, db_id): get_identifiers_url(db, db_id)
+            get_curie(db, db_id): get_url(db, db_id)
             for db, db_id in self.get_groundings()
         }
 

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -145,7 +145,7 @@ def get_curie(db, id) -> Optional[str]:
     if len(id_parts) == 1:
         return curie_pattern.format(db=db.lower(), id=id)
     elif len(id_parts) == 2:
-        return curie_pattern.format(db=id_parts[0].upper(), id=id_parts[-1])
+        return curie_pattern.format(db=id_parts[0].lower(), id=id_parts[-1])
 
 
 def get_url(db, id):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -6,8 +6,8 @@ from typing import Iterable, Optional, Set, Tuple
 
 __all__ = [
     "Term",
-    "get_identifiers_curie",
-    "get_identifiers_url",
+    "get_curie",
+    "get_url",
     "filter_out_duplicates",
     "dump_terms",
 ]
@@ -101,10 +101,10 @@ class Term(object):
 
     def get_curie(self) -> str:
         """Get the compact URI for this term."""
-        return get_identifiers_curie(self.db, self.id)
+        return get_curie(self.db, self.id)
 
-    def get_idenfiers_url(self):
-        return get_identifiers_url(self.db, self.id)
+    def get_url(self):
+        return get_url(self.db, self.id)
 
     def get_groundings(self) -> Set[Tuple[str, str]]:
         """Return all groundings for this term, including from a mapped source.
@@ -137,7 +137,7 @@ class Term(object):
         return namespaces
 
 
-def get_identifiers_curie(db, id) -> Optional[str]:
+def get_curie(db, id) -> Optional[str]:
     curie_pattern = '{db}:{id}'
     if db == 'UP':
         db = 'uniprot'
@@ -148,10 +148,10 @@ def get_identifiers_curie(db, id) -> Optional[str]:
         return curie_pattern.format(db=id_parts[0].upper(), id=id_parts[-1])
 
 
-def get_identifiers_url(db, id):
-    curie = get_identifiers_curie(db, id)
+def get_url(db, id):
+    curie = get_curie(db, id)
     if curie is not None:
-        return f'https://identifiers.org/{curie}'
+        return f'https://bioregistry.io/{curie}'
 
 
 def _term_key(term: Term) -> Tuple[str, str, str, str, str]:

--- a/gilda/tests/test_term.py
+++ b/gilda/tests/test_term.py
@@ -1,22 +1,24 @@
-from gilda.term import Term, get_identifiers_url
+from gilda.term import Term, get_url
 
 
 def test_standalone_get_url():
-    assert get_identifiers_url('UP', 'P12345') == \
-        'https://identifiers.org/uniprot:P12345'
-    assert get_identifiers_url('HGNC', '12345') == \
-        'https://identifiers.org/hgnc:12345'
-    assert get_identifiers_url('CHEBI', 'CHEBI:12345') == \
-        'https://identifiers.org/CHEBI:12345'
+    assert get_url('UP', 'P12345') == \
+        'https://bioregistry.io/uniprot:P12345'
+    assert get_url('HGNC', '12345') == \
+        'https://bioregistry.io/hgnc:12345'
+    assert get_url('CHEBI', 'CHEBI:12345') == \
+        'https://bioregistry.io/chebi:12345'
 
 
 def test_term_get_url():
     term = Term(db='CHEBI', id='CHEBI:12345', entry_name='X',
                 norm_text='x', text='X', source='test', status='name')
     assert term.get_curie() == \
-           'CHEBI:12345'
-    assert term.get_idenfiers_url() == \
-        'https://identifiers.org/CHEBI:12345'
+           'chebi:12345'
+    assert term.get_url() == \
+        'https://bioregistry.io/chebi:12345'
+    assert term.get_url() == \
+        'https://bioregistry.io/chebi:12345'
     assert term.get_groundings() == {(term.db, term.id)}
     assert term.get_namespaces() == {term.db}
 


### PR DESCRIPTION
This PR updates the URL generation and curie presentation:

- Generated URLs are now pointing to `bioregistry.io` rather than `identifiers.org`.
- Curies are now all lowercase for the namespace.