### PR TITLE
Fix raw norm

### DIFF
--- a/gilda/ner.py
+++ b/gilda/ner.py
@@ -70,7 +70,7 @@ def _load_stoplist() -> Set[str]:
     """Load NER stoplist from file."""
     stoplist_path = STOPLIST_PATH
     with open(stoplist_path, 'r') as file:
-        stoplist = {normalize(line.strip()) for line in file}
+        stoplist = {line.strip() for line in file}
     return stoplist
 
 
@@ -143,6 +143,8 @@ def annotate(
             if idx < skip_until:
                 continue
             if word in stop_words:
+                continue
+            if raw_words[idx] in stop_words:
                 continue
             spans = grounder.prefix_index.get(word, set())
             if not spans:

--- a/gilda/ner.py
+++ b/gilda/ner.py
@@ -70,7 +70,7 @@ def _load_stoplist() -> Set[str]:
     """Load NER stoplist from file."""
     stoplist_path = STOPLIST_PATH
     with open(stoplist_path, 'r') as file:
-        stoplist = {line.strip() for line in file}
+        stoplist = {normalize(line.strip()) for line in file}
     return stoplist
 
 


### PR DESCRIPTION
When annotating, gilda will reference the ner_stoplist, however this comparison is done with the normalized strings in the text, against non-normalized stopwords in the file, which causes them to be missed. This pull request resolves this by having the unnormalized word be referenced against the stoplist.