### PR TITLE
Create fuzzy grounding

### DIFF
--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -48,7 +48,9 @@ correct_assertions = {'Stat': {'FPLX': 'STAT'},
                       'integrin alpha': {'FPLX': 'ITGA'},
                       'DC': {'MESH': 'D003713'},
                       'BMD': {'MESH': 'D015519'},
-                      'angina': {'MESH': 'D000787', 'EFO': '0003913'}}
+                      'angina': {'MESH': 'D000787', 'EFO': '0003913'},
+                      'glucorticoid receptor': {'HGNC': '7978'},
+                      'dasatinb': {'CHEBI': 'CHEBI:49375'}}
 
 
 incorrect_assertions = {'IGF': {'HGNC': '5464'},
@@ -66,7 +68,11 @@ incorrect_assertions = {'IGF': {'HGNC': '5464'},
                         'thioredoxin-1': {'UP': 'P47938'},
                         'alpha4': {'HGNC': '10809'},
                         'NT': {'HGNC': '17941'},
-                        'IMP1': {'HGNC': '16435'}}
+                        'IMP1': {'HGNC': '16435'},
+                        'CDK7/9 inhibitor': {'CHEBI': 'CHEBI:82665'},
+                        'PTPMeg2': {'HGNC': '9656'},
+                        'CK2alpha': {'HGNC': '2459'},
+                        'DNA binding domain': {'MESH': 'D000071376'}}
 
 
 def process_fplx_groundings(df):
@@ -139,7 +145,7 @@ def evaluate_new_grounding(grounding, term):
     return 'unknown'
 
 
-def make_comparison(groundings, use_disamb=True):
+def make_comparison(groundings, use_disamb=True, use_fuzzy_matching=False):
     # Generate an initial comparison matrix
     # This dict contains counts of all the possible relationships between
     # the reference grounding and the one produced by Gilda
@@ -155,7 +161,8 @@ def make_comparison(groundings, use_disamb=True):
         # Send grounding requests
         context = grounding['context'] if use_disamb else None
         matches = ground(text=grounding['text'],
-                         context=context)
+                         context=context,
+                         fuzzy=use_fuzzy_matching)
         if not matches:
             comparison['%s_ungrounded' % old_eval].append((idx, grounding,
                                                            None))
@@ -258,13 +265,13 @@ def print_statistics(comparison):
                        label="tab:famplex-confusion"))
 
 
-def run_comparison(use_disamb=True):
+def run_comparison(use_disamb=True, use_fuzzy_matching=False):
     df = pandas.read_csv(url)
     groundings = process_fplx_groundings(df)
-    comparison = make_comparison(groundings, use_disamb)
+    comparison = make_comparison(groundings, use_disamb, use_fuzzy_matching)
     print_statistics(comparison)
     return comparison
 
 
 if __name__ == '__main__':
-    comparison = run_comparison(use_disamb=True)
+    comparison = run_comparison(use_disamb=True, use_fuzzy_matching=True)

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -23,10 +23,11 @@ class GrounderInstance(object):
         return self.grounder
 
     def ground(self, text, context=None, organisms=None,
-               namespaces=None):
+               namespaces=None, fuzzy=None):
         return self.get_grounder().ground(text, context=context,
                                           organisms=organisms,
-                                          namespaces=namespaces)
+                                          namespaces=namespaces,
+                                          fuzzy=fuzzy)
 
     def get_models(self):
         return self.get_grounder().get_models()
@@ -44,7 +45,7 @@ class GrounderInstance(object):
 grounder = GrounderInstance()
 
 
-def ground(text, context=None, organisms=None, namespaces=None):
+def ground(text, context=None, organisms=None, namespaces=None, fuzzy=None):
     """Return a list of scored matches for a text to ground.
 
     Parameters
@@ -61,6 +62,10 @@ def ground(text, context=None, organisms=None, namespaces=None):
     namespaces : Optional[List[str]]
         A list of namespaces to restrict the matches to. By default, no
         restriction is applied.
+    fuzzy: Optional[bool]
+        Wether to use fuzzy matching. If True, the grounder will try to 
+        approximately match the text to the terms. This is useful for cases 
+        where the text may have misspellings or variation.
 
     Returns
     -------
@@ -104,7 +109,7 @@ def ground(text, context=None, organisms=None, namespaces=None):
 
     >>> scored_matches = gilda.ground('ESR', namespaces=["hgnc"])
     """
-    return grounder.ground(text=text, context=context, organisms=organisms, namespaces=namespaces)
+    return grounder.ground(text=text, context=context, organisms=organisms, namespaces=namespaces, fuzzy=fuzzy)
 
 
 def annotate(

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -196,7 +196,7 @@ class Grounder(object):
         fuzzy_hits = process.extract(
             norm,
             self._all_keys,
-            scorer=fuzz.QRatio,
+            scorer=fuzz.ratio,
             score_cutoff=90,
             limit=10
         )

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -246,6 +246,10 @@ class Grounder(object):
             matches, and to the source namespaces of terms if they were
             created using cross-reference mappings. By default, no
             restriction is applied.
+        fuzzy: bool
+            Wether to use fuzzy matching. If True, the grounder will try to 
+            approximately match the text to the terms. This is useful for cases 
+            where the text may have misspellings or variation.
 
         Returns
         -------
@@ -297,6 +301,10 @@ class Grounder(object):
             matches, and to the source namespaces of terms if they were
             created using cross-reference mappings. By default, no
             restriction is applied.
+        fuzzy: bool
+            Wether to use fuzzy matching. If True, the grounder will try to 
+            approximately match the text to the terms. This is useful for cases 
+            where the text may have misspellings or variation.
 
         Returns
         -------

--- a/gilda/ner.py
+++ b/gilda/ner.py
@@ -70,7 +70,7 @@ def _load_stoplist() -> Set[str]:
     """Load NER stoplist from file."""
     stoplist_path = STOPLIST_PATH
     with open(stoplist_path, 'r') as file:
-        stoplist = {normalize(line.strip()) for line in file}
+        stoplist = {line.strip() for line in file}
     return stoplist
 
 
@@ -143,6 +143,8 @@ def annotate(
             if idx < skip_until:
                 continue
             if word in stop_words:
+                continue
+            if raw_words[idx] in stop_words:
                 continue
             spans = grounder.prefix_index.get(word, set())
             if not spans:

--- a/gilda/ner.py
+++ b/gilda/ner.py
@@ -70,7 +70,7 @@ def _load_stoplist() -> Set[str]:
     """Load NER stoplist from file."""
     stoplist_path = STOPLIST_PATH
     with open(stoplist_path, 'r') as file:
-        stoplist = {line.strip() for line in file}
+        stoplist = {normalize(line.strip()) for line in file}
     return stoplist
 
 

--- a/gilda/scorer.py
+++ b/gilda/scorer.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from .process import replace_dashes, replace_whitespace, normalize, \
     get_capitalization_pattern
+from .term import FuzzyTerm
 
 __all__ = [
     "Match",
@@ -251,5 +252,9 @@ def score_status(term):
 def score(match, term):
     string_match_score = score_string_match(match)
     status_score = score_status(term)
-    score = ((0 * 5 + status_score) * 2 + string_match_score) / 9
+    score = (status_score * 2 + string_match_score) / 9
+
+    if isinstance(term, FuzzyTerm):
+        score = score * term.ratio
+    
     return score

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -136,14 +136,14 @@ class Term(object):
             namespaces.add(self.source_db)
         return namespaces
 
-class ScoredTerm(Term):
+class FuzzyTerm(Term):
     """A class that extends Term to include a score for fuzzy matching.
     This class is used to represent a term with an associated score, which can be
     useful for ranking or filtering terms based on their similarity to a given input.
 
     """
 
-    def __init__(self, term: Term, score: float):
+    def __init__(self, term: Term, ratio: float):
         """Initialize a ScoredTerm instance.
 
         Args:
@@ -162,7 +162,13 @@ class ScoredTerm(Term):
             source_db=term.source_db,
             source_id=term.source_id,
         )
-        self.score = score
+        self.ratio = ratio
+    
+    def __str__(self):
+        return 'FuzzyTerm(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%.2f)' % (
+            self.norm_text, self.text, self.db, self.id, self.entry_name,
+            self.status, self.source, self.organism, self.source_db,
+            self.source_id, self.ratio)
 
 def get_identifiers_curie(db, id) -> Optional[str]:
     curie_pattern = '{db}:{id}'

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -136,6 +136,33 @@ class Term(object):
             namespaces.add(self.source_db)
         return namespaces
 
+class ScoredTerm(Term):
+    """A class that extends Term to include a score for fuzzy matching.
+    This class is used to represent a term with an associated score, which can be
+    useful for ranking or filtering terms based on their similarity to a given input.
+
+    """
+
+    def __init__(self, term: Term, score: float):
+        """Initialize a ScoredTerm instance.
+
+        Args:
+            term (Term): The Term object to be wrapped.
+            score (float): The score associated with the term.
+        """
+        super().__init__(
+            term.norm_text,
+            term.text,
+            term.db,
+            term.id,
+            term.entry_name,
+            term.status,
+            term.source,
+            organism=term.organism,
+            source_db=term.source_db,
+            source_id=term.source_id,
+        )
+        self.score = score
 
 def get_identifiers_curie(db, id) -> Optional[str]:
     curie_pattern = '{db}:{id}'


### PR DESCRIPTION
Fuzzy grounding using `rapidfuzz` library is integrated using the optional keyword `fuzzy` as part of `api.py` and `grounder.py`. So that it can be called on a `gilda.grounder.Grounder` instance:

```Grounder().ground('dasatinb', fuzzy=True)```
```Grounder().ground_best('dasatinb', fuzzy=True)```

or using the api with:

```gilda.ground('dasatinb', fuzzy=True)```

