### PR TITLE
Fix method name for getting identifiers URL

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -578,7 +578,7 @@ class ScoredMatch(object):
     def __init__(self, term: Term, score, match: Match, disambiguation=None,
                  subsumed_terms=None):
         self.term = term
-        self.url = term.get_idenfiers_url()
+        self.url = term.get_identifiers_url()
         self.score = score
         self.match = match
         self.disambiguation = disambiguation

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -103,8 +103,13 @@ class Term(object):
         """Get the compact URI for this term."""
         return get_identifiers_curie(self.db, self.id)
 
-    def get_idenfiers_url(self):
+    def get_identifiers_url(self):
+        """Get the full identifiers.org URL for this term."""
         return get_identifiers_url(self.db, self.id)
+
+    # Backwards compatibility for the misspelled method name
+    def get_idenfiers_url(self):  # pragma: no cover - deprecated spelling
+        return self.get_identifiers_url()
 
     def get_groundings(self) -> Set[Tuple[str, str]]:
         """Return all groundings for this term, including from a mapped source.

--- a/gilda/tests/test_term.py
+++ b/gilda/tests/test_term.py
@@ -15,7 +15,7 @@ def test_term_get_url():
                 norm_text='x', text='X', source='test', status='name')
     assert term.get_curie() == \
            'CHEBI:12345'
-    assert term.get_idenfiers_url() == \
+    assert term.get_identifiers_url() == \
         'https://identifiers.org/CHEBI:12345'
     assert term.get_groundings() == {(term.db, term.id)}
     assert term.get_namespaces() == {term.db}


### PR DESCRIPTION
## Summary
- fix typo in Term method `get_identifiers_url`
- update ScoredMatch to use the corrected method
- update unit tests for the new name

## Testing
- `pytest gilda/tests/test_term.py -q` *(fails: ModuleNotFoundError: No module named 'adeft')*

------
https://chatgpt.com/codex/tasks/task_e_6880f6bc0634832aa31973502fc137c4